### PR TITLE
heart: Use ntohs instead of manual conversion

### DIFF
--- a/src/heart.c
+++ b/src/heart.c
@@ -494,11 +494,8 @@ static int heart_cmd_reply(const char *s)
  */
 static int write_message(int fd, const struct msg *mp)
 {
-    int   len;
-    const char *tmp;
+    int len = ntohs(mp->len);
 
-    tmp = (const char *) & (mp->len);
-    len = (*tmp * 256) + *(tmp + 1);
     if ((len == 0) || (len > MSG_BODY_SIZE)) {
         return MSG_HDR_SIZE;
     }             /* cc68k wants (char *) */


### PR DESCRIPTION
Merge fix from upstream:

Author: John Högberg <john@erlang.org>
Date:   Tue Apr 24 13:30:00 2018 +0200

    heart: Use ntohs instead of manual conversion

    Multiplying a signed char by 256 is undefined behavior and caused
    problems on some platforms when the length was long enough. We
    could cast it to an unsigned int to make it work, but it's best not
    to reinvent the wheel.

    Fixes OTP-15034