### PR TITLE
Identify nerves_heart and its version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 VERSION=0.3.0
 
-CFLAGS+=-Wall -Wextra -O2 -DPROGRAM_VERSION=$(VERSION)
+ADDITIONAL_CFLAGS=-Wall -Wextra -DPROGRAM_VERSION=$(VERSION)
 
 all: heart
 
 heart: src/heart.c
-	$(CC) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(ADDITIONAL_CFLAGS) -o $@ $^
 
 install: heart
 	cp $^ $(PREFIX)/lib/erlang/erts-9.3/bin/heart

--- a/src/heart.c
+++ b/src/heart.c
@@ -93,6 +93,15 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#define PROGRAM_NAME "nerves_heart"
+#ifndef PROGRAM_VERSION
+#error PROGRAM_VERSION is undefined
+#endif
+
+#define xstr(s) str(s)
+#define str(s) #s
+#define PROGRAM_VERSION_STR xstr(PROGRAM_VERSION)
+
 #define ERL_CRASH_DUMP_SECONDS_ENV "ERL_CRASH_DUMP_SECONDS"
 #define HEART_KILL_SIGNAL          "HEART_KILL_SIGNAL"
 #define HEART_WATCHDOG_PATH        "HEART_WATCHDOG_PATH"
@@ -262,6 +271,8 @@ int main(int argc, char **argv)
         dup2(log_fd, STDERR_FILENO);
         close(log_fd);
     }
+
+    print_log("heart: " PROGRAM_NAME " v" PROGRAM_VERSION_STR " started.");
 
     get_arguments(argc, argv);
     notify_ack();


### PR DESCRIPTION
When debugging Erlang/OTP, it's easy to overwrite nerves_heart with the
OTP heart program and then have the hardware watchdog reset. If you're
connected to the console UART it's possible to see that the wrong heart
is running, but this makes it easier.
