### PR TITLE
Support manual trigger of heart timeouts; add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,13 @@ works, you can instruct `heart` to stop petting the hardware watchdog by
 running:
 
 ```elixir
-iex> :heart.set_cmd("attack_hw")
+iex> :heart.set_cmd("disable_hw")
 ```
-If you'd like to verify that the Erlang VM watchdog kicks in, you can instruct `heart`
-to stop as it would if the Erlang VM became unresponsive by running:
+
+If you'd like to verify how the Erlang VM handles the `heart` process detecting
+an unresponsive VM, you can instruct `heart` to stop as it would if it timed out
+on the VM by running:
 
 ```elixir
-iex> :heart.set_cmd("attack_vm")
+iex> :heart.set_cmd("disable_vm")
 ```

--- a/README.md
+++ b/README.md
@@ -118,8 +118,11 @@ works, you can instruct `heart` to stop petting the hardware watchdog by
 running:
 
 ```elixir
-iex> :heart.set_cmd("disable")
+iex> :heart.set_cmd("attack_hw")
 ```
+If you'd like to verify that the Erlang VM watchdog kicks in, you can instruct `heart`
+to stop as it would if the Erlang VM became unresponsive by running:
 
-If anyone knows of an easy way of making the Erlang VM unresponsive, please let
-me know or send a PR to fill in this section.
+```elixir
+iex> :heart.set_cmd("attack_vm")
+```

--- a/src/heart.c
+++ b/src/heart.c
@@ -157,8 +157,6 @@ pid_t heart_beat_kill_pid = 0;
 #define  R_ERROR            (3)
 #define  R_SHUT_DOWN        (4)
 #define  R_CRASHING         (5) /* Doing a crash dump and we will wait for it */
-#define  R_TEST_VM_ATTACK   (6)
-
 
 /*  macros */
 
@@ -358,21 +356,21 @@ static int message_loop()
                 case SHUT_DOWN:
                     return R_SHUT_DOWN;
                 case SET_CMD:
-                    /* If the user specifies "disable" or "attack_hw", turn off the hw watchdog petter to verify that the system reboots. */
+                    /* If the user specifies "disable" or "disable_hw", turn off the hw watchdog petter to verify that the system reboots. */
                     if ((mp->len > 7 && memcmp(mp->fill, "disable", 7) == 0) ||
-                        (mp->len > 9 && memcmp(mp->fill, "attack_hw", 9) == 0)) {
+                        (mp->len > 10 && memcmp(mp->fill, "disable_hw", 10) == 0)) {
                         print_log("heart: Petting of the hardware watchdog is disabled. System should reboot momentarily.");
 
                         /* Disable petting of the hardware watchdog */
                         watchdog_open_retries = 0;
                         watchdog_fd = -1;
                     }
-                    /* If the user specifies "attack_vm", simply return */
-                    if (mp->len > 9 && memcmp(mp->fill, "attack_vm", 9) == 0) {
-                        print_log("heart: Forced software watchdog reset. System should reboot momentarily.");
+                    /* If the user specifies "disable_vm", return like there was a timeout */
+                    if (mp->len > 10 && memcmp(mp->fill, "disable_vm", 10) == 0) {
+                        print_log("heart: Forced heart process timeout. System should reboot momentarily.");
 
                         notify_ack();
-                        return R_TEST_VM_ATTACK;
+                        return R_TIMEOUT;
                     }
                     notify_ack();
                     break;

--- a/src/heart.c
+++ b/src/heart.c
@@ -348,6 +348,8 @@ static int message_loop()
                 return R_ERROR;
             }
             if ((tlen > MSG_HDR_SIZE) && (tlen <= MSG_TOTAL_SIZE)) {
+                int mp_len = htons(mp->len);
+
                 switch (mp->op) {
                 case HEART_BEAT:
                     pet_watchdog();
@@ -357,8 +359,8 @@ static int message_loop()
                     return R_SHUT_DOWN;
                 case SET_CMD:
                     /* If the user specifies "disable" or "disable_hw", turn off the hw watchdog petter to verify that the system reboots. */
-                    if ((mp->len > 7 && memcmp(mp->fill, "disable", 7) == 0) ||
-                        (mp->len > 10 && memcmp(mp->fill, "disable_hw", 10) == 0)) {
+                    if ((mp_len == 8 && memcmp(mp->fill, "disable", 7) == 0) ||
+                        (mp_len == 11 && memcmp(mp->fill, "disable_hw", 10) == 0)) {
                         print_log("heart: Petting of the hardware watchdog is disabled. System should reboot momentarily.");
 
                         /* Disable petting of the hardware watchdog */
@@ -366,7 +368,7 @@ static int message_loop()
                         watchdog_fd = -1;
                     }
                     /* If the user specifies "disable_vm", return like there was a timeout */
-                    if (mp->len > 10 && memcmp(mp->fill, "disable_vm", 10) == 0) {
+                    if (mp_len == 11 && memcmp(mp->fill, "disable_vm", 10) == 0) {
                         print_log("heart: Forced heart process timeout. System should reboot momentarily.");
 
                         notify_ack();

--- a/src/heart.c
+++ b/src/heart.c
@@ -157,6 +157,7 @@ pid_t heart_beat_kill_pid = 0;
 #define  R_ERROR            (3)
 #define  R_SHUT_DOWN        (4)
 #define  R_CRASHING         (5) /* Doing a crash dump and we will wait for it */
+#define  R_TEST_VM_ATTACK   (6)
 
 
 /*  macros */
@@ -357,13 +358,21 @@ static int message_loop()
                 case SHUT_DOWN:
                     return R_SHUT_DOWN;
                 case SET_CMD:
-                    /* If the user specifies "disable", turn off the hw watchdog petter to verify that the system reboots. */
-                    if (mp->len > 7 && memcmp(mp->fill, "disable", 7) == 0) {
+                    /* If the user specifies "disable" or "attack_hw", turn off the hw watchdog petter to verify that the system reboots. */
+                    if ((mp->len > 7 && memcmp(mp->fill, "disable", 7) == 0) ||
+                        (mp->len > 9 && memcmp(mp->fill, "attack_hw", 9) == 0)) {
                         print_log("heart: Petting of the hardware watchdog is disabled. System should reboot momentarily.");
 
                         /* Disable petting of the hardware watchdog */
                         watchdog_open_retries = 0;
                         watchdog_fd = -1;
+                    }
+                    /* If the user specifies "attack_vm", simply return */
+                    if (mp->len > 9 && memcmp(mp->fill, "attack_vm", 9) == 0) {
+                        print_log("heart: Forced software watchdog reset. System should reboot momentarily.");
+
+                        notify_ack();
+                        return R_TEST_VM_ATTACK;
                     }
                     notify_ack();
                     break;

--- a/tests/heart_test/test/heart_test.exs
+++ b/tests/heart_test/test/heart_test.exs
@@ -82,18 +82,29 @@ defmodule HeartTestTest do
     assert Heart.next_event(heart) == {:exit, 0}
   end
 
-  test "sending disable stops petting the hardware watchdog", context do
+  test "sending disable_hw stops petting the hardware watchdog", context do
     heart = start_supervised!({Heart, tmp_dir: context.tmp_dir})
     assert Heart.next_event(heart) == {:heart, :heart_ack}
     assert Heart.next_event(heart) == {:event, "open(/dev/watchdog0) succeeded"}
 
-    {:ok, :heart_ack} = Heart.set_cmd(heart, "disable")
+    {:ok, :heart_ack} = Heart.set_cmd(heart, "disable_hw")
 
     Process.sleep(10000)
 
     assert Heart.next_event(heart, 1000) == :timeout
 
     Heart.shutdown(heart)
+    assert Heart.next_event(heart) == {:exit, 0}
+  end
+
+  test "sending disable_vm causes a heart timeout exit", context do
+    heart = start_supervised!({Heart, tmp_dir: context.tmp_dir})
+    assert Heart.next_event(heart) == {:heart, :heart_ack}
+    assert Heart.next_event(heart) == {:event, "open(/dev/watchdog0) succeeded"}
+
+    {:ok, :heart_ack} = Heart.set_cmd(heart, "disable_vm")
+
+    assert Heart.next_event(heart) == {:event, "reboot(0x01234567)"}
     assert Heart.next_event(heart) == {:exit, 0}
   end
 


### PR DESCRIPTION
This rebases/extracts one of the changes in #16. The other commits are to add a
unit test, change the command to disable_* to bring up to date, and fix an issue
that was found by the test.

- Add test for VM watchdog
- Change attack to disable; disable via timeout code path
- Fix endian issue with heart command check
- Add unit test for disable_vm
