### PR TITLE
Add sync before reboot to reduce lost data

### DIFF
--- a/src/heart.c
+++ b/src/heart.c
@@ -464,6 +464,7 @@ do_terminate(int reason)
     case R_CLOSED:
     case R_ERROR:
     default:
+        sync();
         kill_old_erlang(reason);
         reboot(LINUX_REBOOT_CMD_RESTART);
         break;

--- a/tests/heart_test/c_src/heart_fixture.c
+++ b/tests/heart_test/c_src/heart_fixture.c
@@ -83,6 +83,11 @@ __attribute__((constructor)) void fixture_init()
     unsetenv("DYLD_INSERT_LIBRARIES");
 }
 
+REPLACE(void, sync, ())
+{
+    flog("sync()");
+}
+
 REPLACE(int, reboot, (int cmd))
 {
     flog("reboot(0x%08x)", cmd);

--- a/tests/heart_test/test/heart_test.exs
+++ b/tests/heart_test/test/heart_test.exs
@@ -54,6 +54,7 @@ defmodule HeartTestTest do
 
     assert Heart.next_event(heart) == {:event, "pet(1)"}
     assert Heart.next_event(heart) == {:event, "pet(1)"}
+    assert Heart.next_event(heart) == {:event, "sync()"}
     assert Heart.next_event(heart) == {:event, "reboot(0x01234567)"}
     assert Heart.next_event(heart) == {:exit, 0}
   end
@@ -104,6 +105,7 @@ defmodule HeartTestTest do
 
     {:ok, :heart_ack} = Heart.set_cmd(heart, "disable_vm")
 
+    assert Heart.next_event(heart) == {:event, "sync()"}
     assert Heart.next_event(heart) == {:event, "reboot(0x01234567)"}
     assert Heart.next_event(heart) == {:exit, 0}
   end


### PR DESCRIPTION
This is motivated by a change in #16. The addition of the sync(2) call
in that PR was to ensure that a log file was written.

While the log file in that PR doesn't exist, calling sync(2) before
reboot(2) is good for reducing other data loss due to reboot(2) being
very ungraceful in restarting the system.
