### PR TITLE
Be more precise on WDT pet timeout

### DIFF
--- a/tests/heart_test/c_src/heart_fixture.c
+++ b/tests/heart_test/c_src/heart_fixture.c
@@ -47,6 +47,7 @@
 
 static int to_elixir_fd = -1;
 static int open_tries = 0;
+static int wdt_timeout = 0;
 
 static void flog(const char *format, ...)
 {
@@ -65,6 +66,7 @@ __attribute__((constructor)) void fixture_init()
 {
     char *report_path = getenv("HEART_REPORT_PATH");
     open_tries = atoi(getenv("HEART_WATCHDOG_OPEN_TRIES"));
+    wdt_timeout = atoi(getenv("WDT_TIMEOUT"));
 
     to_elixir_fd = socket(AF_UNIX, SOCK_DGRAM, 0);
     if (to_elixir_fd < 0)
@@ -212,7 +214,7 @@ REPLACE(int, ioctl, (int fd, unsigned long request, ...))
     case WDIOC_GETTIMEOUT:
         {
             int *v = va_arg(ap, int *);
-            *v = 120;
+            *v = wdt_timeout;
             break;
         }
     case WDIOC_SETPRETIMEOUT:
@@ -230,7 +232,7 @@ REPLACE(int, ioctl, (int fd, unsigned long request, ...))
     case WDIOC_GETTIMELEFT:
         {
             int *v = va_arg(ap, int *);
-            *v = 116;
+            *v = wdt_timeout - 4;
             break;
         }
 


### PR DESCRIPTION
The original code would pet the hardware watchdog (WDT) every 5 seconds
and on heart beat messages from Erlang. This worked for hardware
watchdog timeouts in the official Nerves systems.

This update breaks out the timeouts for the WDT so that they're separate
from the Erlang VM timer and not summarized in a select timeout. The
main point is to make it easier to communicate how timeouts work with
nerves_heart with other people.

A side effect of this change is that the WDT will be pet less frequently
than before on devices that have WDT pet times > 5 seconds (pet time is
less than the WDT timeout). For example, if the Erlang heart beat
interval is 60s and the WDT timeout is 120s, the WDT will be pet every
time Erlang sends a heart beat message. That will likely be >5s. For the
case where the WDT timeout is less than the Erlang heart beat interval,
nerves_heart will bet the WDT either 10 seconds before the WDT timeout
or half the WDT timeout, whichever is longer. This change is small
enough that it's doubtful if anyone would notice unless they instrument
the system and measure the delays.

This also updates the status printout to log the timeouts.
