### PR TITLE
Add support for WDT guarded reboots and poweroffs

### DIFF
--- a/tests/heart_test/c_src/heart_fixture.c
+++ b/tests/heart_test/c_src/heart_fixture.c
@@ -103,7 +103,16 @@ REPLACE(int, reboot, (int cmd))
 
 REPLACE(int, kill, (pid_t pid, int sig))
 {
-    flog("kill(%d, %d)", pid, sig);
+    const char *signal_name;
+    switch (sig) {
+    case SIGTERM: signal_name = "SIGTERM"; break;
+    case SIGKILL: signal_name = "SIGKILL"; break;
+    case SIGUSR1: signal_name = "SIGUSR1"; break;
+    case SIGUSR2: signal_name = "SIGUSR2"; break;
+    default: signal_name = "UNEXPECTED!"; break;
+    }
+
+    flog("kill(%d, %s)", pid, signal_name);
     return 0;
 }
 


### PR DESCRIPTION
This makes it possible to coordinate reboots and poweroffs with Nerves
heart. It has few nice features:

1. The HW WDT can be pet one last time and then never again (unless
   someone else pets it). The HW WDT is another layer of protection
   against a reboot/poweroff hang.
2. No OS processes need to be started to reboot or poweroff. I.e., you
   don't have to include Busybox `reboot` or `poweroff` to signal PID 1.
3. It calls `sync` after petting the WDT the last time and notifying PID
   1 just in case something happens there.

This change was made in response to reports of hangs when calling
reboot. It's possible that none of these changes help those reports, but
they do remove some possible hang scenarios for the next time this is
encountered.
