### PR TITLE
Formalize setting heart print messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,21 @@ on the VM by running:
 ```elixir
 iex> :heart.set_cmd("disable_vm")
 ```
+
+## Debugging
+
+Nerves Heart writes to the kernel's logger to aid debug if something unexpected
+happens.  Only errors are logged by default. If you'd like informational
+messages as well, set the `HEART_VERBOSE` environment variable in your
+`vm.args.eex`:
+
+```erlang
+-env HEART_VERBOSE 2
+```
+
+If you want Nerves Heart to be completely stealth in its prints for some
+reason, set `HEART_VERBOSE` to `0`:
+
+```erlang
+-env HEART_VERBOSE 0
+```

--- a/tests/heart_test/test/test_helper.exs
+++ b/tests/heart_test/test/test_helper.exs
@@ -1,7 +1,7 @@
 ExUnit.start()
 
-# Comment out to get log messages from Nerves heart
-System.put_env("HEART_SILENT", "1")
+# Set to 1 or 2 to get log messages from Nerves heart
+System.put_env("HEART_VERBOSE", "0")
 
 defmodule HeartTestCommon do
   use ExUnit.Case


### PR DESCRIPTION
This removes the undocumented `HEART_SILENT` and adds `HEART_VERBOSE` to
control the level of output. By default, errors and important messages
are logged like before. The heart banner isn't shown by default any more
unless `HEART_VERBOSE=2`. The reasons are that it is more reliable to get
this information using `Nerves.Runtime.Heart` now, and the info prints
could write over Elixir/Erlang prints on the serial console.
