### PR TITLE
Support overriding the hardware watchdog timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ If you need to change the watchdog path, you can do this through an environment 
 -env HEART_WATCHDOG_PATH /dev/watchdog1
 ```
 
+The following table shows the environment variables that affect Nerves Heart:
+
+| Variable                 | Description |
+| ------------------------ | ----------- |
+| `HEART_BEAT_TIMEOUT`     | Used by Erlang to start `heart`. Erlang promises to pet `heart` before this timeout. |
+| `HEART_INIT_TIMEOUT`     | If set, require an init handshake message before the timeout
+| `ERL_CRASH_DUMP_SECONDS` | Timeout in seconds to wait for Erlang to exit
+| `HEART_KILL_SIGNAL`      | Set to "SIGABRT" to send `SIGABRT` rather than `SIGKILL`
+| `HEART_WATCHDOG_PATH`    | Path to hardware watchdog. Defaults to `"/dev/watchdog0"`
+| `HEART_NO_KILL`          | If "TRUE", don't try to kill Erlang before exiting
+| `HEART_VERBOSE`          | "0" turns off logging, "1" is error logs only, "2" is everything
+| `HEART_WATCHDOG_TIMEOUT` | Override the hardware watchdog timeout (must be between 2 and 120 seconds)
+
 ## Linux kernel configuration
 
 All official Nerves systems have Linux configured of Nerves Heart.

--- a/tests/heart_test/lib/heart.ex
+++ b/tests/heart_test/lib/heart.ex
@@ -76,7 +76,7 @@ defmodule Heart do
     heart_beat_timeout = init_args[:heart_beat_timeout] || 60
     open_tries = init_args[:open_tries] || 0
     watchdog_path = init_args[:watchdog_path]
-    wdt_timeout = init_args[:wdt_timeout] || 120
+    wdt_timeout = init_args[:wdt_timeout]
     crash_dump_seconds = init_args[:crash_dump_seconds]
     init_timeout = init_args[:init_timeout]
 
@@ -89,7 +89,7 @@ defmodule Heart do
 
     wdt_timeout_env =
       if wdt_timeout do
-        [{~c"WDT_TIMEOUT", ~c"#{wdt_timeout}"}]
+        [{~c"HEART_WATCHDOG_TIMEOUT", ~c"#{wdt_timeout}"}]
       else
         []
       end


### PR DESCRIPTION
This looked like it was supported in the unit tests, but it actually
wasn't. This commit fixes that and adds guard rails to prevent
accidentally setting the timeout too short or too long.
