### PR TITLE
Add snooze feature to delay a reboot temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,22 @@ on the VM by running:
 iex> :heart.set_cmd("disable_vm")
 ```
 
+## Snoozing
+
+If you're debugging a watchdog or Erlang heart issue, it can be really helpful
+to disable reboots temporarily. This is called snoozing and it works by telling
+`heart` to pet the hardware watchdog and keep the Erlang VM running even if it
+should reboot. This is effective for the next 15 minutes every time you run it.
+
+```elixir
+iex> :heart.set_cmd("snooze")
+```
+
+The reason snoozing forever isn't supported is to avoid keeping a device on
+forever in a bad state. For example, it would be unfortunate to start a debug
+session on a remote device and accidentally mess it up in a way where you lose
+connectivity until the next reboot.
+
 ## Debugging
 
 Nerves Heart writes to the kernel's logger to aid debug if something unexpected

--- a/tests/heart_test/test/snooze_test.exs
+++ b/tests/heart_test/test/snooze_test.exs
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022 Nerves Project Developers
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule SnoozeTest do
+  use ExUnit.Case, async: true
+
+  import HeartTestCommon
+
+  setup do
+    common_setup()
+  end
+
+  test "snooze avoids reboot", context do
+    # Shortest timeout is 11 seconds
+    heart =
+      start_supervised!({Heart, context.init_args ++ [heart_beat_timeout: 11, wdt_timeout: 2]})
+
+    assert_receive {:heart, :heart_ack}
+    assert_receive {:event, "open(/dev/watchdog0) succeeded"}
+    assert_receive {:event, "pet(1)"}
+
+    {:ok, :heart_ack} = Heart.set_cmd(heart, "snooze")
+    # Check for immediate petting of the watchdog
+    assert_receive {:event, "pet(1)"}
+
+    # Check that the watchdog is pet automatically
+    assert_receive {:event, "pet(1)"}, 2500
+    assert_receive {:event, "pet(1)"}, 2500
+    assert_receive {:event, "pet(1)"}, 2500
+    assert_receive {:event, "pet(1)"}, 2500
+    assert_receive {:event, "pet(1)"}, 2500
+
+    # This will get us past the Erlang heart beat timeout of 11 seconds
+    assert_receive {:event, "pet(1)"}, 2500
+
+    refute_receive {:exit, 0}, 100
+  end
+end


### PR DESCRIPTION
This is necessary when remote debugging an issue where the watchdog
timer goes off at an inconvenient time. The idea is that you can snooze
heart for 15 minutes and it will pet the watchdog and not kill Erlang to
give you more time to debug.
