### PR TITLE
Support watchdog pet timeouts down to 2 seconds

### DIFF
--- a/src/heart.c
+++ b/src/heart.c
@@ -151,6 +151,9 @@ struct msg {
 #define  DEFAULT_WDT_TIMEOUT        10
 #define  WDT_PET_TIMEOUT_BUFFER     10 /* Pet the watchdog 10 seconds before it would expire (or half its timeout) */
 #define  DEFAULT_WDT_PET_TIMEOUT    (DEFAULT_WDT_TIMEOUT / 2)
+#define  MIN_WDT_PET_TIMEOUT        2 /* Limited by pet timer's resolution in seconds */
+#define  MAX_WDT_PET_TIMEOUT        120
+
 static int wdt_pet_timeout = DEFAULT_WDT_PET_TIMEOUT;
 
 /* heart_beat_timeout is the maximum gap in seconds between two
@@ -277,7 +280,7 @@ static void try_open_watchdog()
         int ret;
 
         ret = ioctl(watchdog_fd, WDIOC_GETTIMEOUT, &real_wdt_timeout);
-        if (ret == 0 && real_wdt_timeout >= 5) {
+        if (ret == 0 && real_wdt_timeout >= MIN_WDT_PET_TIMEOUT) {
             wdt_timeout = real_wdt_timeout;
             /* Most of the time, pet WDT_PET_TIMEOUT_BUFFER seconds before the timeout,
              * but if it's really short, then pet half the timeout.

--- a/tests/heart_test/c_src/heart_fixture.c
+++ b/tests/heart_test/c_src/heart_fixture.c
@@ -257,7 +257,7 @@ REPLACE(int, ioctl, (int fd, unsigned long request, ...))
     case WDIOC_GETTIMELEFT:
         {
             int *v = va_arg(ap, int *);
-            *v = wdt_timeout - 4;
+            *v = wdt_timeout / 2;
             break;
         }
 

--- a/tests/heart_test/test/status_test.exs
+++ b/tests/heart_test/test/status_test.exs
@@ -33,7 +33,7 @@ defmodule StatusTest do
              "wdt_options" => "settimeout,magicclose,keepaliveping,",
              "wdt_pet_time_left" => "110",
              "wdt_pre_timeout" => "0",
-             "wdt_time_left" => "116",
+             "wdt_time_left" => "60",
              "wdt_timeout" => "120"
            }
 


### PR DESCRIPTION
Sadly, shorter watchdog pet timeouts require a bigger change, but going
down to 2 seconds seems fine.
