### PR TITLE
Add minimum run time before even trying to reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ implementation and provides the following changes:
 6. Support for an application-level initialization handshake. This lets your
    application guard against conditions that cause Erlang and Nerves Heart to
    think that everything is ok when it's not. See discussion below.
+7. Support for snoozing timeouts and assuring an uninterrupted amount of time at
+   start. This makes heart friendlier to remote debug where it's nice when the
+   watchdog doesn't get in your way of debugging. These timeouts are limited to
+   avoid accidentally putting the device in a state where it can't recover.
+8. Includes many regression tests make it easier to modify and maintain.
 
 ## Timeouts and semantics
 
@@ -111,10 +116,10 @@ The following table shows the environment variables that affect Nerves Heart:
 | `HEART_BEAT_TIMEOUT`     | Used by Erlang to start `heart`. Erlang promises to pet `heart` before this timeout. |
 | `HEART_INIT_TIMEOUT`     | If set, require an init handshake message before the timeout |
 | `HEART_KILL_SIGNAL`      | Set to "SIGABRT" to send `SIGABRT` rather than `SIGKILL` |
+| `HEART_MIN_RUN_TIME`     | Minimum amount of time to let Erlang run on start. E.g., if set to 120, then `heart` will pet the watchdog automatically and not reboot regardless of what Erlang does. |
 | `HEART_NO_KILL`          | If "TRUE", don't try to kill Erlang before exiting |
 | `HEART_VERBOSE`          | "0" turns off logging, "1" is error logs only, "2" is everything |
 | `HEART_WATCHDOG_PATH`    | Path to hardware watchdog. Defaults to `"/dev/watchdog0"` |
-| `HEART_MIN_RUN_TIME`     | Minimum amount of time to let Erlang run on start. E.g., if set to 120, then `heart` will pet the watchdog automatically and not reboot regardless of what Erlang does. |
 
 ## Linux kernel configuration
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,14 @@ The following table shows the environment variables that affect Nerves Heart:
 
 | Variable                 | Description |
 | ------------------------ | ----------- |
-| `ERL_CRASH_DUMP_SECONDS` | Timeout in seconds to wait for Erlang to exit
+| `ERL_CRASH_DUMP_SECONDS` | Timeout in seconds to wait for Erlang to exit |
 | `HEART_BEAT_TIMEOUT`     | Used by Erlang to start `heart`. Erlang promises to pet `heart` before this timeout. |
-| `HEART_INIT_TIMEOUT`     | If set, require an init handshake message before the timeout
-| `HEART_KILL_SIGNAL`      | Set to "SIGABRT" to send `SIGABRT` rather than `SIGKILL`
-| `HEART_NO_KILL`          | If "TRUE", don't try to kill Erlang before exiting
-| `HEART_VERBOSE`          | "0" turns off logging, "1" is error logs only, "2" is everything
-| `HEART_WATCHDOG_PATH`    | Path to hardware watchdog. Defaults to `"/dev/watchdog0"`
+| `HEART_INIT_TIMEOUT`     | If set, require an init handshake message before the timeout |
+| `HEART_KILL_SIGNAL`      | Set to "SIGABRT" to send `SIGABRT` rather than `SIGKILL` |
+| `HEART_NO_KILL`          | If "TRUE", don't try to kill Erlang before exiting |
+| `HEART_VERBOSE`          | "0" turns off logging, "1" is error logs only, "2" is everything |
+| `HEART_WATCHDOG_PATH`    | Path to hardware watchdog. Defaults to `"/dev/watchdog0"` |
+| `HEART_MIN_RUN_TIME`     | Minimum amount of time to let Erlang run on start. E.g., if set to 120, then `heart` will pet the watchdog automatically and not reboot regardless of what Erlang does. |
 
 ## Linux kernel configuration
 

--- a/tests/heart_test/test/min_run_time_test.exs
+++ b/tests/heart_test/test/min_run_time_test.exs
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2022 Nerves Project Developers
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule MinRunTimeTest do
+  use ExUnit.Case, async: true
+
+  import HeartTestCommon
+
+  setup do
+    common_setup()
+  end
+
+  test "heart doesn't reboot when not petted before min_run_time", context do
+    # Shortest timeout is 11 seconds
+    start_supervised!(
+      {Heart, context.init_args ++ [heart_beat_timeout: 11, wdt_timeout: 10, min_run_time: 12]}
+    )
+
+    assert_receive {:heart, :heart_ack}, 500
+    assert_receive {:event, "open(/dev/watchdog0) succeeded"}
+    assert_receive {:event, "pet(1)"}
+
+    # Wait for 2 pet (10 seconds total)
+    refute_receive _, 4500
+    assert_receive {:event, "pet(1)"}, 1000
+    refute_receive _, 4500
+    assert_receive {:event, "pet(1)"}, 1000
+    refute_received _
+
+    # At the 12 second mark, we're passed the min_run_time grace period. If it fails
+    # on the next line, min_run_time is broke.
+    refute_receive _, 4500
+    assert_receive {:event, "pet(1)"}, 1000
+    refute_receive _, 4500
+    assert_receive {:event, "pet(1)"}, 1000
+    refute_received _
+
+    # Now we're 3 seconds from the 23 second mark (12s min_run_time + 11s hb_timeout) when the exit happens.
+    refute_receive _, 2800
+    assert_receive {:event, "sync()"}, 500
+    assert_receive {:event, "reboot(0x01234567)"}
+    assert_receive {:exit, 0}
+  end
+end


### PR DESCRIPTION
This add support for `HEART_MIN_RUN_TIME`. If set to a number of
seconds, Nerves Heart won't let the system reboot for that amount of
time. For example, if you want the system to be up for 2 minutes so that
there's time to connect to the internet and get instructions, then set
`HEART_MIN_RUN_TIME` to 120. The max amount of time is 600 seconds or 10
minutes.
