### PR TITLE
Rename min_run_time to init_grace_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following table shows the environment variables that affect Nerves Heart:
 | `HEART_BEAT_TIMEOUT`     | Used by Erlang to start `heart`. Erlang promises to pet `heart` before this timeout. |
 | `HEART_INIT_TIMEOUT`     | If set, require an init handshake message before the timeout |
 | `HEART_KILL_SIGNAL`      | Set to "SIGABRT" to send `SIGABRT` rather than `SIGKILL` |
-| `HEART_MIN_RUN_TIME`     | Minimum amount of time to let Erlang run on start. E.g., if set to 120, then `heart` will pet the watchdog automatically and not reboot regardless of what Erlang does. |
+| `HEART_INIT_GRACE_TIME`  | Grace period for Erlang at the start. E.g., if set to 120, then `heart` will pet the hardware watchdog for the first two minutes even if Erlang isn't responsive. |
 | `HEART_NO_KILL`          | If "TRUE", don't try to kill Erlang before exiting |
 | `HEART_VERBOSE`          | "0" turns off logging, "1" is error logs only, "2" is everything |
 | `HEART_WATCHDOG_PATH`    | Path to hardware watchdog. Defaults to `"/dev/watchdog0"` |

--- a/tests/heart_test/lib/heart.ex
+++ b/tests/heart_test/lib/heart.ex
@@ -79,7 +79,7 @@ defmodule Heart do
     wdt_timeout = init_args[:wdt_timeout] || 120
     crash_dump_seconds = init_args[:crash_dump_seconds]
     init_timeout = init_args[:init_timeout]
-    min_run_time = init_args[:min_run_time]
+    init_grace_time = init_args[:init_grace_time]
 
     File.exists?(shim) || raise "Can't find heart_fixture.so"
     File.exists?(heart) || raise "Can't find heart"
@@ -105,8 +105,8 @@ defmodule Heart do
         if init_timeout do
           {~c"HEART_INIT_TIMEOUT", ~c"#{init_timeout}"}
         end,
-        if min_run_time do
-          {~c"HEART_MIN_RUN_TIME", ~c"#{min_run_time}"}
+        if init_grace_time do
+          {~c"HEART_INIT_GRACE_TIME", ~c"#{init_grace_time}"}
         end,
         {~c"LD_PRELOAD", c_shim},
         {~c"DYLD_INSERT_LIBRARIES", c_shim},

--- a/tests/heart_test/test/init_grace_time_test.exs
+++ b/tests/heart_test/test/init_grace_time_test.exs
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-defmodule MinRunTimeTest do
+defmodule InitGraceTimeTest do
   use ExUnit.Case, async: true
 
   import HeartTestCommon
@@ -11,10 +11,10 @@ defmodule MinRunTimeTest do
     common_setup()
   end
 
-  test "heart doesn't reboot when not petted before min_run_time", context do
+  test "heart doesn't reboot when not petted before init_grace_time", context do
     # Shortest timeout is 11 seconds
     start_supervised!(
-      {Heart, context.init_args ++ [heart_beat_timeout: 11, wdt_timeout: 10, min_run_time: 12]}
+      {Heart, context.init_args ++ [heart_beat_timeout: 11, wdt_timeout: 10, init_grace_time: 12]}
     )
 
     assert_receive {:heart, :heart_ack}, 500
@@ -28,15 +28,15 @@ defmodule MinRunTimeTest do
     assert_receive {:event, "pet(1)"}, 1000
     refute_received _
 
-    # At the 12 second mark, we're passed the min_run_time grace period. If it fails
-    # on the next line, min_run_time is broke.
+    # At the 12 second mark, we're passed the init_grace_time grace period. If it fails
+    # on the next line, init_grace_time is broke.
     refute_receive _, 4500
     assert_receive {:event, "pet(1)"}, 1000
     refute_receive _, 4500
     assert_receive {:event, "pet(1)"}, 1000
     refute_received _
 
-    # Now we're 3 seconds from the 23 second mark (12s min_run_time + 11s hb_timeout) when the exit happens.
+    # Now we're 3 seconds from the 23 second mark (12s init_grace_time + 11s hb_timeout) when the exit happens.
     refute_receive _, 2800
     assert_receive {:event, "sync()"}, 500
     assert_receive {:event, "reboot(0x01234567)"}

--- a/tests/heart_test/test/status_test.exs
+++ b/tests/heart_test/test/status_test.exs
@@ -25,7 +25,7 @@ defmodule StatusTest do
              "init_handshake_happened" => "1",
              "init_handshake_time_left" => "0",
              "init_handshake_timeout" => "0",
-             "min_run_time_left" => "0",
+             "init_grace_time_left" => "0",
              "program_name" => "nerves_heart",
              "program_version" => "2.1.0",
              "snooze_time_left" => "0",


### PR DESCRIPTION
There was some confusion with "minimum run time" so the next try is to
call it an "initial grace period".
