### PR TITLE
Add immediate poweroff/reboot commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run: reuse lint
   build:
     docker:
-      - image: cimg/elixir:1.14.1
+      - image: cimg/elixir:1.16.0
     steps:
       - checkout
       - run: mix local.hex --force

--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ the WDT will be pet for the last time. You should then call either
 `:init.stop/0` (graceful) or `:erlang.halt/0` (ungraceful) to exit the Erlang
 VM. Both `erlinit` and the WDT will prevent shutdown from not completing.
 
+It's also possible to do a totally ungraceful reboot or shutdown if you need a
+very immediate response. The `"guarded_immediate_reboot"` and
+`"guarded_immediate_poweroff"` commands do this.
+
 ## Testing
 
 It's reassuring to know that `heart` does what it's supposed to do since it
@@ -346,6 +350,23 @@ reason, set `HEART_VERBOSE` to `0`:
 -env HEART_VERBOSE 0
 ```
 
+## Heart set_cmd summary
+
+The following commands can be sent to Nerves Heart via `:heart.set_cmd`:
+
+| Command                        | Description           |
+| ------------------------------ | --------------------- |
+| `"disable"`                    | Same as `"disable_hw"` |
+| `"disable_hw"`                 | Stop petting the hardware watchdog |
+| `"disable_vm"`                 | Return a timeout to Erlang |
+| `"init_handshake"`             | Stop the initialization timeout timer |
+| `"guarded_immediate_poweroff"` | Stop petting the watchdog and immediately power off |
+| `"guarded_immediate_reboot"`   | Stop petting the watchdog and immediately reboot |
+| `"guarded_halt"`               | Stop petting the watchdog and start a graceful halt |
+| `"guarded_poweroff"`           | Stop petting the watchdog and start a graceful power off |
+| `"guarded_reboot"`             | Stop petting the watchdog and start a graceful reboot |
+| `"snooze"`                     | Don't stop petting the watchdog for the next 15 minutes |
+
 ## License
 
 This production code in this project is Erlang/OTP's `heart.c` with custom
@@ -362,4 +383,3 @@ Exceptions to Apache-2.0 licensing are:
 * Documentation is CC-BY-4.0
 * Linux kernel headers for MacOS development are GPL-2.0-only with the Linux
   syscall note.
-

--- a/src/heart.c
+++ b/src/heart.c
@@ -559,13 +559,23 @@ static int message_loop()
 
                         LOG_ERROR("heart: reboot signaled. No longer petting the WDT");
                         sync();
-                    } else if (mp_len == 17 && memcmp(m.fill, "guarded_poweroff", 16) == 0) {
+                    } else if (mp_len == 25 && memcmp(m.fill, "guarded_immediate_reboot", 24) == 0) {
+                        stop_petting_watchdog();
+                        reboot(LINUX_REBOOT_CMD_RESTART);
+
+                        LOG_ERROR("heart: immediate reboot signaled. No longer petting the WDT");
+                     } else if (mp_len == 17 && memcmp(m.fill, "guarded_poweroff", 16) == 0) {
                         pet_watchdog(now);
                         stop_petting_watchdog();
                         kill(1, SIGUSR2); // SIGUSR2 signals "poweroff" to PID 1
 
                         LOG_ERROR("heart: poweroff signaled. No longer petting the WDT");
                         sync();
+                    } else if (mp_len == 27 && memcmp(m.fill, "guarded_immediate_poweroff", 26) == 0) {
+                        stop_petting_watchdog();
+                        reboot(LINUX_REBOOT_CMD_POWER_OFF);
+
+                        LOG_ERROR("heart: immediate poweroff signaled. No longer petting the WDT");
                     } else if (mp_len == 13 && memcmp(m.fill, "guarded_halt", 12) == 0) {
                         pet_watchdog(now);
                         stop_petting_watchdog();

--- a/tests/heart_test/test/immediate_reboot_test.exs
+++ b/tests/heart_test/test/immediate_reboot_test.exs
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022 Nerves Project Developers
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule ImmediateRebootTest do
+  use ExUnit.Case, async: true
+
+  import HeartTestCommon
+
+  setup do
+    common_setup()
+  end
+
+  test "guarded reboot", context do
+    heart = start_supervised!({Heart, context.init_args})
+    assert_receive {:heart, :heart_ack}, 500
+    assert_receive {:event, "open(/dev/watchdog0) succeeded"}
+    assert_receive {:event, "pet(1)"}
+
+    assert Heart.set_cmd(heart, "guarded_immediate_reboot") == {:error, :exit}
+
+    # Kernel reboot
+    assert_receive {:event, "reboot(0x01234567)"}
+    refute_receive _
+  end
+
+  test "guarded immediate poweroff", context do
+    heart = start_supervised!({Heart, context.init_args})
+    assert_receive {:heart, :heart_ack}, 500
+    assert_receive {:event, "open(/dev/watchdog0) succeeded"}
+    assert_receive {:event, "pet(1)"}
+
+    assert Heart.set_cmd(heart, "guarded_immediate_poweroff") == {:error, :exit}
+
+    # Kernel reboot
+    assert_receive {:event, "reboot(0x4321fedc)"}
+    refute_receive _
+  end
+end


### PR DESCRIPTION
This enables that work better with immediate handling of the reboot or
power off request. This is useful when graceful shutdown can have
unwanted side effects or when the ramifications of immediate reboots are
less severe than any delay incurred to gracefully clean up the system.
