### PR TITLE
Add pmsg breadcrumbs to help debug watchdog reboots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 all: heart
 
-heart: src/heart.c $(EXTRA_SRC)
+heart: src/heart.c src/elog.c $(EXTRA_SRC)
 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $^
 
 test: check

--- a/README.md
+++ b/README.md
@@ -351,6 +351,20 @@ reason, set `HEART_VERBOSE` to `0`:
 -env HEART_VERBOSE 0
 ```
 
+## Pstore breadcrumbs
+
+The logging described above doesn't always work when watchdogs start rebooting
+systems. To get around this limitation, Nerves Heart also writes notable events
+to the Linux pstore's `pmsg` circular buffer. When enabled and configured,
+`pmsg` survives reboots even though it's an in-memory buffer. The tradeoff is
+that you can't write a lot to it.
+
+See the Linux `pstore` documentation and the
+[ramoops_logger](https://hex.pm/packages/ramoops_logger) for more details.
+
+Currently there's nothing to configure and Nerves Heart will automatically write
+breadcrumbs if it can.
+
 ## Heart set_cmd summary
 
 The following commands can be sent to Nerves Heart via `:heart.set_cmd`:

--- a/src/elog.c
+++ b/src/elog.c
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2025 Frank Hunleth
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "elog.h"
+
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef PROGRAM_NAME
+#define PROGRAM_NAME "nerves_heart"
+#endif
+#ifndef ELOG_FACILITY
+#define ELOG_FACILITY 3 // LOG_DAEMON
+#endif
+
+int elog_level = ELOG_LEVEL_INFO;
+
+static int kmsg_format(int severity, char **strp, const char *msg)
+{
+    int prival = ELOG_FACILITY * 8 + (severity & ELOG_SEVERITY_MASK);
+    return asprintf(strp, "<%d>" PROGRAM_NAME ": %s\n", prival, msg);
+}
+
+static int stderr_format(char **strp, const char *msg)
+{
+    return asprintf(strp, PROGRAM_NAME ": %s\n", msg);
+}
+
+static int pmsg_format(char **strp, const char *msg)
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+        return -1;
+
+    struct tm tm;
+    if (gmtime_r(&ts.tv_sec, &tm) == NULL)
+        return -1;
+
+    long usec = ts.tv_nsec / 1000;
+
+    // Match the RFC3339 timestamps from Erlang's logger_formatter
+    // 2025-12-04T00:01:34.200744+00:00
+    return asprintf(
+            strp,
+            "%04d-%02d-%02dT%02d:%02d:%02d.%06ld+00:00 " PROGRAM_NAME " %s\n",
+            tm.tm_year + 1900,
+            tm.tm_mon + 1,
+            tm.tm_mday,
+            tm.tm_hour,
+            tm.tm_min,
+            tm.tm_sec,
+            usec,
+            msg
+        );
+}
+
+static void log_pmsg_breadcrumb(const char *msg)
+{
+    static int open_failed = 0;
+
+    // Don't bother trying again on failures.
+    if (open_failed)
+        return;
+
+    int pmsg_fd = open("/dev/pmsg0", O_WRONLY | O_CLOEXEC);
+    if (pmsg_fd < 0) {
+        open_failed = 1;
+        return;
+    }
+
+    char *str;
+    int len = pmsg_format(&str, msg);
+    if (len > 0) {
+        ssize_t ignore = write(pmsg_fd, str, len);
+        (void) ignore;
+        free(str);
+    }
+    close(pmsg_fd);
+}
+
+static void log_write(int severity, const char *msg)
+{
+    char *str;
+    ssize_t ignore;
+    int log_fd = open("/dev/kmsg", O_WRONLY | O_CLOEXEC);
+    if (log_fd >= 0) {
+        int len = kmsg_format(severity, &str, msg);
+        if (len > 0) {
+            ignore = write(log_fd, str, len);
+            free(str);
+        }
+        close(log_fd);
+    } else {
+        int len = stderr_format(&str, msg);
+        if (len > 0) {
+            ignore = write(STDERR_FILENO, str, len);
+            free(str);
+        }
+    }
+    (void) ignore;
+}
+
+void elog(int severity, const char *fmt, ...)
+{
+    int level = severity & ELOG_SEVERITY_MASK;
+    int log_pmsg = severity & ELOG_PMSG;
+    if (level <= elog_level || log_pmsg) {
+        va_list ap;
+        va_start(ap, fmt);
+
+        char *msg;
+        if (vasprintf(&msg, fmt, ap) > 0) {
+            if (log_pmsg)
+                log_pmsg_breadcrumb(msg);
+
+            if (level <= elog_level)
+                log_write(severity, msg);
+
+            free(msg);
+        }
+
+        va_end(ap);
+    }
+}

--- a/src/elog.h
+++ b/src/elog.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 Frank Hunleth
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef ELOG_H
+#define ELOG_H
+
+// See /usr/include/syslog.h for values. They're also standardized in RFC5424.
+#define ELOG_LEVEL_EMERG   0
+#define ELOG_LEVEL_ALERT   1
+#define ELOG_LEVEL_CRIT    2
+#define ELOG_LEVEL_ERROR   3
+#define ELOG_LEVEL_WARNING 4
+#define ELOG_LEVEL_NOTICE  5
+#define ELOG_LEVEL_INFO    6
+#define ELOG_LEVEL_DEBUG   7
+#define ELOG_LEVEL_DONT_LOG 8
+
+#define ELOG_SEVERITY_MASK 0xf
+#define ELOG_PMSG (1 << 4)     // Log to /dev/pmsg0 if available
+
+// Callers normally use these macros so that errors and more severe levels (not warnings) always get to pmsg
+#define ELOG_EMERG     (ELOG_LEVEL_EMERG | ELOG_PMSG)
+#define ELOG_ALERT     (ELOG_LEVEL_ALERT | ELOG_PMSG)
+#define ELOG_CRIT      (ELOG_LEVEL_CRIT | ELOG_PMSG)
+#define ELOG_ERROR     (ELOG_LEVEL_ERROR | ELOG_PMSG)
+#define ELOG_WARNING   (ELOG_LEVEL_WARNING)
+#define ELOG_NOTICE    (ELOG_LEVEL_NOTICE)
+#define ELOG_INFO      (ELOG_LEVEL_INFO)
+#define ELOG_DEBUG     (ELOG_LEVEL_DEBUG)
+#define ELOG_PMSG_ONLY (ELOG_LEVEL_DONT_LOG | ELOG_PMSG)
+
+// Global logging level
+extern int elog_level;
+
+// Logging functions
+void elog(int severity, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
+
+#endif // ELOG_H

--- a/src/heart.c
+++ b/src/heart.c
@@ -336,7 +336,7 @@ static void try_open_watchdog()
             elog(ELOG_ERROR, "error or too short WDT timeout so using defaults!");
         }
 
-        elog(ELOG_INFO, "kernel watchdog activated. WDT timeout %ds, WDT pet interval %ds, VM timeout %ds, initial grace period %lds", wdt_timeout, wdt_pet_timeout, heart_beat_timeout, (long) init_grace_time);
+        elog(ELOG_INFO | ELOG_PMSG, "kernel watchdog activated. WDT timeout %ds, WDT pet interval %ds, VM timeout %ds, initial grace period %lds", wdt_timeout, wdt_pet_timeout, heart_beat_timeout, (long) init_grace_time);
     } else {
         watchdog_open_retries--;
         if (watchdog_open_retries <= 0) {
@@ -429,7 +429,7 @@ int main(int argc, char **argv)
 {
     set_logging_verbosity();
 
-    elog(ELOG_INFO, "" PROGRAM_NAME " v" PROGRAM_VERSION_STR " started.");
+    elog(ELOG_INFO | ELOG_PMSG, PROGRAM_NAME " " PROGRAM_VERSION_STR);
 
     // Assume that the handshake happened and this fixes it if a timeout was specified
     init_handshake_happened = 1;
@@ -585,38 +585,38 @@ static int message_loop()
                         stop_petting_watchdog();
                         kill(1, SIGTERM); // SIGTERM signals "reboot" to PID 1
 
-                        elog(ELOG_INFO, "Guarded reboot requested. No longer petting the WDT");
+                        elog(ELOG_INFO | ELOG_PMSG, "Guarded reboot requested. No longer petting the WDT");
                         sync();
                     } else if (mp_len == 25 && memcmp(m.fill, "guarded_immediate_reboot", 24) == 0) {
                         stop_petting_watchdog();
                         reboot(LINUX_REBOOT_CMD_RESTART);
 
-                        elog(ELOG_INFO, "Guarded immediate reboot requested. No longer petting the WDT");
+                        elog(ELOG_INFO | ELOG_PMSG, "Guarded immediate reboot requested. No longer petting the WDT");
                      } else if (mp_len == 17 && memcmp(m.fill, "guarded_poweroff", 16) == 0) {
                         pet_watchdog(now);
                         stop_petting_watchdog();
                         kill(1, SIGUSR2); // SIGUSR2 signals "poweroff" to PID 1
 
-                        elog(ELOG_INFO, "Guarded poweroff requested. No longer petting the WDT");
+                        elog(ELOG_INFO | ELOG_PMSG, "Guarded poweroff requested. No longer petting the WDT");
                         sync();
                     } else if (mp_len == 27 && memcmp(m.fill, "guarded_immediate_poweroff", 26) == 0) {
                         stop_petting_watchdog();
                         reboot(LINUX_REBOOT_CMD_POWER_OFF);
 
-                        elog(ELOG_INFO, "Guarded immediate poweroff requested. No longer petting the WDT");
+                        elog(ELOG_INFO | ELOG_PMSG, "Guarded immediate poweroff requested. No longer petting the WDT");
                     } else if (mp_len == 13 && memcmp(m.fill, "guarded_halt", 12) == 0) {
                         pet_watchdog(now);
                         stop_petting_watchdog();
                         kill(1, SIGUSR1); // SIGUSR1 signals "halt" to PID 1
 
-                        elog(ELOG_INFO, "Guarded halt requested. No longer petting the WDT");
+                        elog(ELOG_INFO | ELOG_PMSG, "Guarded halt requested. No longer petting the WDT");
                         sync();
                     } else if (mp_len == 15 && memcmp(m.fill, "init_handshake", 14) == 0) {
                         /* Application has said that it's completed initialization */
-                        elog(ELOG_INFO, "Received init handshake");
+                        elog(ELOG_INFO | ELOG_PMSG, "Received init handshake");
                         init_handshake_happened = 1;
                     } else if (mp_len == 7 && memcmp(m.fill, "snooze", 6) == 0) {
-                        elog(ELOG_WARNING, "Snoozing heart keepalive checks for 15 minutes");
+                        elog(ELOG_WARNING | ELOG_PMSG, "Snoozing heart keepalive checks for 15 minutes");
                         snooze_requested = 1;
                     }
                     notify_ack();
@@ -660,7 +660,7 @@ kill_old_erlang(int reason)
 
     if (heart_beat_kill_pid != 0) {
         if (reason == R_CLOSED) {
-            elog(ELOG_INFO, "Wait 5 seconds for Erlang to terminate nicely");
+            elog(ELOG_INFO | ELOG_PMSG, "Wait 5 seconds for Erlang to terminate nicely");
             for (i=0; i < 5; ++i) {
                res = kill(heart_beat_kill_pid, 0); /* check if alive */
                if (res < 0 && errno == ESRCH)


### PR DESCRIPTION
This pulls out the logging code since it was getting long, and it's basically a
copy/paste from erlinit.

The logging code currently favors low frequency logging in that it will retry
opening log files rather than keeping handles around. It is currently not
intended to be a fast logger.
